### PR TITLE
Create Early_access_opens_for_OnDemand

### DIFF
--- a/docs/General/Announcements/Early_access_opens_for_OnDemand
+++ b/docs/General/Announcements/Early_access_opens_for_OnDemand
@@ -1,0 +1,33 @@
+---
+created: 2025-02-17
+description: "Early access is now available for OnDemand, NeSI's new interactive computing environment."
+tags: refresh
+---
+
+As part of NeSI’s platform refresh, we’re beginning to migrate NeSI users to one of our first new service offerings – OnDemand. 
+
+Built on the open source Open OnDemand product from Ohio Supercomputing Center, OnDemand is our new platform that enables researchers to access high performance computing via an interactive web or notebook interface. 
+OnDemand ensures easy access to tools like Jupyter and RStudio. Additional apps (such as MatLab, Code Server, and Virtual Desktops) will be released for use over the coming months. 
+
+So far, feedback from our first onboarded users has been positive. We’re looking forward to rolling out incremental improvements over the next few months. 
+This initial release of OnDemand does not yet support GPUs and is not connected to the Slurm cluster or high-performance filesystem. These additional features will be delivered in the coming months.
+
+
+
+## Interactive applications
+
+
+A number of interactive applications can be accessed through NeSI OnDemand, including:
+
+- JupyterLab
+- RStudio
+- MATLAB - currently under development, let us know if this is of interest
+- Code server - currently under development, let us know if this is of interest
+- Virtual desktop - currently under development, let us know if this is of interest
+
+
+## How to access
+
+
+OnDemand is currently in development and accessible only to early access users. If you are interested in becoming an early access user, please get in touch. 
+Note: This initial release of NeSI OnDemand does not currently support large analysis, as it is not yet connected to the Slurm cluster or high-performance filesystem yet.


### PR DESCRIPTION
a standalone announcement page for OnDemand open to early access users, so that we can point to it from the Latest Updates page