### PR TITLE
Update .pages.yml

### DIFF
--- a/docs/General/Announcements/.pages.yml
+++ b/docs/General/Announcements/.pages.yml
@@ -1,8 +1,7 @@
 ---
 nav:
+  - Preparing_to_move_data_to_NeSI_long_term_storage.md
+  - Accessing_NeSI_Support_during_the_Easter_break.md
   - Early_access_opens_for_OnDemand.md
   - Visual_Studio_Code_Remote-Next_Release_Not_Supported.md
-  - Preparing_to_move_data_to_NeSI_long_term_storage.md
   - Preparing_your_code_for_use_on_NeSIs_new_HPC_platform.md
-  - Accessing_NeSI_Support_during_the_holiday_break.md
-  - Improved_data_management_and_efficient_use_of_NeSI_HPC_storage.md


### PR DESCRIPTION
removed an old page (from 2021 about auto-deletion processes) and re-ordered the pages so the update about Nearline is at the top and the Easter Break notice is second