### PR TITLE
Update Adding SSH key

### DIFF
--- a/docs/Scientific_Computing/Terminal_Setup/Standard_Terminal_Setup.md
+++ b/docs/Scientific_Computing/Terminal_Setup/Standard_Terminal_Setup.md
@@ -132,7 +132,7 @@ Generating a SSH key on the cluster removes one of the login prompts when using 
 
     ```sh
     mkdir -p ~/.ssh
-    [ -f .ssh/id_rsa ] || ssh-key -t rsa -q -N ""
+    [ -f .ssh/id_rsa ] || ssh-keygen -t rsa -q -N ""
     cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
     ```
 


### PR DESCRIPTION
I noticed when I performed the steps in `Adding a SSH key (optional)`, the steps didnt work if I performed:

scp mahuika:~/.ssh/mahuika_key.pub ~/.ssh/

but if I performed

scp mahuika:~/.ssh/mahuika_key ~/.ssh/

I can ssh into mahuika with only one webpage login as expected.

ISSUE: I'm wondering if this change I have made is unsecure because I am transferring the private key over ssh, which probably shouldn't be done.