### PR TITLE
Update MobaXterm moving files

### DIFF
--- a/docs/Getting_Started/Next_Steps/Moving_files_to_and_from_the_cluster.md
+++ b/docs/Getting_Started/Next_Steps/Moving_files_to_and_from_the_cluster.md
@@ -1,15 +1,10 @@
 ---
 created_at: '2018-11-20T22:41:32Z'
+description: How to upload files from your local machine to the cluster.
 tags:
-- scp
 - transfer
 - copying
 - download
-- upload
-- mv
-- cp
-- move
-- moving
 ---
 
 !!! prerequisite


### PR DESCRIPTION
Long story short, the SCP plugin in MobaXterm does not work/show if you are using the non-interactive method in MobaXterm. You can use this if you set up mahuika using the interactive procedure, but it is a very clunky method. It would be better to use WinSCP. Remove this completely with the web-activated method.