### PR TITLE
Cylc ap

### DIFF
--- a/docs/Scientific_Computing/Supported_Applications/Cylc.md
+++ b/docs/Scientific_Computing/Supported_Applications/Cylc.md
@@ -1,7 +1,6 @@
 ---
 created_at: '2022-08-03T21:35:50Z'
 tags: []
-status: deprecated
 ---
 
 ## What is Cylc


### PR DESCRIPTION
Cylc is no longer installed on our system. This doc shows how to install, configure and test cylc on REANNZ platforms.