### PR TITLE
Revise file deletion instructions for clarity

### DIFF
--- a/docs/Storage/File_Systems_and_Quotas/Automatic_cleaning_of_nobackup_file_system.md
+++ b/docs/Storage/File_Systems_and_Quotas/Automatic_cleaning_of_nobackup_file_system.md
@@ -35,13 +35,10 @@ There will be ***no exclusions*** to this auto-deletion process. If you need to 
      At any time you can check for and delete files older than 90 days (replace <project code> with the project code of interest, e.g. “nesi99999”):
 
     - (FAST) To list all files that will be deleted, you can unzip and read the list of files that have been marked for deletion:
-    ```bash
-    export $PROJECTNAME=Your_Project_Name
-    gzip -d /search/autocleaner/filelists/$PROJECTNAME.gz > doomed_list_$PROJECTNAME.txt
-    nano doomed_list_$PROJECTNAME.txt
-    ```
+    ```gzip -d /search/autocleaner/filelists/<project code>.gz > doomed_list_<project code>.txt; nano doomed_list_<project code>.txt```
     
-    - (FAST) To search through for files in PROJECTNAME.gz that contain the keyword KEYWORD: ```zgrep KEYWORD /search/autocleaner/filelists/PROJECTNAME.gz```
+    - (FAST) To search through for files in <project code>.gz that contain the keyword KEYWORD: 
+    ```zgrep KEYWORD /search/autocleaner/filelists/<project code>.gz```
 
     - (SLOW) To list all files (and their owners) not accessed within 90 days, run the following command (you may want to redirect the output to a file): 
     ```find /nesi/nobackup/<project code> -type f -atime +90 -ctime +90 -printf '%u : %p\n'```


### PR DESCRIPTION
Updated instructions for checking and deleting files older than 90 days, including faster methods to list files marked for deletion.