### PR TITLE
Modify sacct link formatting in FORMAT.md

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -468,8 +468,9 @@ Instead of
 Use
 
 <pre><code>
-[sacct](https://slurm.schedmd.com/archive/{{config.extra.slurm}}/sacct.html#lbAI)
+{% raw %}[sacct](https://slurm.schedmd.com/archive/{{config.extra.slurm}}/sacct.html#lbAI){% endraw %}
 </code></pre>
+
 
 The current version of Slurm can be changed in the [`mkdocs.yml`](https://github.com/nesi/support-docs/blob/181a3d96716795a04e2c1084be8d1d9b7b45cacf/mkdocs.yml#L67) file.
 


### PR DESCRIPTION
Updated formatting for sacct link in FORMAT.md to use raw markdown syntax.