### PR TITLE
Preparation of the release

### DIFF
--- a/docs/Getting_Started/my-nesi-org-nz/Release_Notes_my-nesi-org-nz/my-nesi-org-nz_release_notes_v2-53-0.md
+++ b/docs/Getting_Started/my-nesi-org-nz/Release_Notes_my-nesi-org-nz/my-nesi-org-nz_release_notes_v2-53-0.md
@@ -1,0 +1,18 @@
+---
+created_at: '2026-06-25T09:00:24Z'
+tags:
+- releasenote
+title: my.nesi.org.nz release notes v2.53.0
+search:
+  boost: 0.1
+---
+
+## New and Improved
+- Default storage values updated: For projects that have been inactive, new allocations will now default to the values from the most recent active allocation.
+- Usage column tooltip added: A tooltip now clarifies that storage usage values are refreshed once every 24 hours.
+
+## Fixed
+- Research outputs restored: The Research Outputs function is now fully operational after being impacted by the previous framework upgrade last month.
+
+If you have any questions about any of the updates, please
+{% include "partials/support_request.html" %}.


### PR DESCRIPTION
New and Improved

When creating a new allocation for a previously inactive project, storage default values are now pre-filled from the project's last active allocation.
A tooltip has been added to the usage column to indicate that usage data is refreshed once every 24 hours.

Fixed

The Research Outputs UI, which was broken in the previous release following a framework upgrade, has been restored and is now fully operational.

I need still to check that we won't include anything else.
