### PR TITLE
Clarify Partition field in Slurm Composer documentation

### DIFF
--- a/docs/Interactive_Computing/OnDemand/Apps/Slurm_Composer.md
+++ b/docs/Interactive_Computing/OnDemand/Apps/Slurm_Composer.md
@@ -46,7 +46,7 @@ The main fields are:
 | Field | What it sets | Slurm option |
 | ----- | ------------ | ------------ |
 | **Project** | The project code your usage is charged to. Only projects you belong to are listed. | `--account` |
-| **Partition** | The type of node to run on. Choose **any** if you have no preference. Options are either Genoa or Milan | `--partition` |
+| **Partition** | The type of node to run on. Choose **any** if you have no preference. Options are either `genoa` or `milan`. [See here for more information about the nodes that make up these partitions](../../../Batch_Computing/Hardware.md#compute-nodes). | `--partition` |
 | **Number of CPUs** | How many CPU cores to request. | `--cpus-per-task` |
 | **Number of Nodes** | How many nodes to spread the job over (leave blank for the default). | `--nodes` |
 | **Total Memory (GB)** | Total RAM for the whole job. | `--mem` |


### PR DESCRIPTION
Updated the Partition field description to specify node options as 'genoa' and 'milan', and added a link for more information about the nodes.