### PR TITLE
Add JupyterLab header to index.md

### DIFF
--- a/docs/Interactive_Computing/OnDemand/Apps/JupyterLab/index.md
+++ b/docs/Interactive_Computing/OnDemand/Apps/JupyterLab/index.md
@@ -5,6 +5,8 @@ tags:
     - OnDemand
 ---
 
+# JupyterLab
+
 ## Introduction
 
 Mahuika supports the use of [Jupyter](https://jupyter.org/) for interactive computing.


### PR DESCRIPTION
Add a header for JupyterLab section in the documentation.