### PR TITLE
Fix llms.txt: restore 58 dropped pages, add per-link descriptions

### DIFF
--- a/checks/run_meta_check.py
+++ b/checks/run_meta_check.py
@@ -30,6 +30,10 @@ msg_count = {"debug": 0, "notice": 0, "warning": 0, "error": 0}
 MAX_TITLE_LENGTH = 28  # As font isn't monospace, this is only approx
 MAX_HEADER_LENGTH = 32  # minus 2 per extra header level
 MIN_TAGS = 1
+# Below this, descriptions stop distinguishing pages ("Release notes", "Freezer Quick
+# Start", eleven Freezer pages all sharing "Freezer upgrade release notes"). Descriptions
+# in the low 30s are still doing real work, so don't raise this without checking.
+MIN_DESCRIPTION_LENGTH = 30
 RANGE_SIBLING = [4, 8]
 ALLOWED_BE_BIG = ["Available_Applications"] # Categories not to trigger too many children warnings.
 # Site-infrastructure pages (tag index, updates feed, glossary) have no topic of their
@@ -340,6 +344,41 @@ def meta_missing_description():
         yield {"message": "Missing 'description' from front matter."}
 
 
+def meta_thin_description():
+    """
+    A description that just restates the title carries no information. These descriptions
+    are what each llms.txt link is annotated with (see mkdocs_hooks.on_config), so a reader
+    picking between pages has only this line to go on - 'Guide to batch computing' on
+    Batch_Computing_Guide.md tells them nothing the title didn't.
+    """
+    description = meta.get("description")
+    if not isinstance(description, str):
+        return
+    description = " ".join(description.split())
+    if not description:
+        return
+    lineno = _get_lineno(r"^description:.*$")
+    if len(description) < MIN_DESCRIPTION_LENGTH:
+        yield {
+            "level": "notice",
+            "line": lineno,
+            "message": f"Description '{description}' is too short to tell pages apart. \
+Aim for at least {MIN_DESCRIPTION_LENGTH} characters saying what the page answers.",
+        }
+    elif title and _squash(description) == _squash(title):
+        yield {
+            "level": "notice",
+            "line": lineno,
+            "message": f"Description '{description}' just restates the title. \
+Say what the page answers instead.",
+        }
+
+
+def _squash(text):
+    """Lowercase and strip everything but letters and digits, for comparing phrasings."""
+    return re.sub(r"[^a-z0-9]", "", text.lower())
+
+
 def title_length():
     if len(title) > MAX_TITLE_LENGTH:
         yield {
@@ -513,6 +552,7 @@ ENDCHECKS = [
     title_length,
     title_capitalisation,
     meta_missing_description,
+    meta_thin_description,
     meta_unexpected_key,
     minimum_tags,
     walk_toc,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,27 +132,31 @@ plugins:
         NeSI Mahuika HPC support documentation: getting access, running batch jobs
         with Slurm, available software and modules, storage and data transfer,
         interactive computing (Jupyter, OnDemand), and platform policies.
+      # These are fnmatch patterns, not pathlib globs - `*` already crosses `/`, so
+      # `Section/*.md` matches every page at any depth. Do NOT "fix" these to `**`:
+      # `Section/**/*.md` requires a literal extra `/`, which silently drops every page
+      # sitting directly in the section directory (it emptied Batch Computing and Policy).
       sections:
         Announcements:
           - Announcements/*.md
         Getting Started:
-          - Getting_Started/**/*.md
+          - Getting_Started/*.md
         Software:
-          - Software/**/*.md
+          - Software/*.md
         Batch Computing:
-          - Batch_Computing/**/*.md
+          - Batch_Computing/*.md
         Interactive Computing:
-          - Interactive_Computing/**/*.md
+          - Interactive_Computing/*.md
         Storage:
-          - Storage/**/*.md
+          - Storage/*.md
         Data Transfer:
-          - Data_Transfer/**/*.md
+          - Data_Transfer/*.md
         Policy:
-          - Policy/**/*.md
+          - Policy/*.md
         Service Subscriptions:
-          - Service_Subscriptions/**/*.md
+          - Service_Subscriptions/*.md
         Tutorials:
-          - Tutorials/**/*.md
+          - Tutorials/*.md
         Reference:
           - GLOSSARY.md
           - index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,6 +136,8 @@ plugins:
       # `Section/*.md` matches every page at any depth. Do NOT "fix" these to `**`:
       # `Section/**/*.md` requires a literal extra `/`, which silently drops every page
       # sitting directly in the section directory (it emptied Batch Computing and Policy).
+      # mkdocs_hooks.on_config rewrites these globs into explicit per-page entries so each
+      # link carries its front matter `description`.
       sections:
         Announcements:
           - Announcements/*.md

--- a/mkdocs_hooks.py
+++ b/mkdocs_hooks.py
@@ -5,12 +5,78 @@ As opposed to `macro_hooks.py` which injects variables into macro rendering (e.g
 If this is confusing, ask Cal to explain.
 """
 
+import fnmatch
 import glob
 from pathlib import Path
 import json
 import os
+import re
+
+import yaml
 
 module_list_path = os.getenv("MODULE_LIST_PATH", "docs/assets/module-list.json")
+
+_FRONT_MATTER = re.compile(r"\A---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+def _page_description(path):
+    """Return a page's front matter `description` as one line, or None."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return None
+    match = _FRONT_MATTER.match(text)
+    if not match:
+        return None
+    try:
+        meta = yaml.safe_load(match.group(1))
+    except yaml.YAMLError:
+        # checks/run_meta_check.py is what reports a malformed meta block; the build
+        # itself should skip the page rather than fall over.
+        return None
+    if not isinstance(meta, dict):
+        return None
+    description = meta.get("description")
+    if not isinstance(description, str):
+        return None
+    # Folded YAML descriptions span several lines; llms.txt entries are one line each.
+    return " ".join(description.split()) or None
+
+
+def on_config(config, **kwargs):
+    """Rewrite the llmstxt section globs into explicit per-page entries.
+
+    mkdocs-llmstxt takes link descriptions only from its own config - it never reads page
+    front matter, and a glob entry hands every page it matches the same description.
+    Expanding the globs here instead lets each llms.txt link carry its own description,
+    which is what lets a reader pick a page without fetching several.
+
+    Hooks are appended last in the plugin collection, so this runs after the plugin's own
+    on_config. The plugin expands `sections` in on_files, so the rewrite still lands.
+    """
+    plugin = config.plugins.get("llmstxt")
+    if plugin is None:
+        return config
+
+    docs_dir = Path(config.docs_dir)
+    uris = sorted(p.relative_to(docs_dir).as_posix() for p in docs_dir.rglob("*.md"))
+
+    sections = {}
+    for section, patterns in plugin.config.sections.items():
+        entries = []
+        seen = set()
+        for pattern in patterns:
+            matches = sorted(fnmatch.filter(uris, pattern)) if "*" in pattern else [pattern]
+            for uri in matches:
+                if uri in seen:
+                    continue
+                seen.add(uri)
+                description = _page_description(docs_dir / uri)
+                entries.append({uri: description} if description else uri)
+        sections[section] = entries
+
+    plugin.config.sections = sections
+    return config
 
 
 def on_env(env, config, files, **kwargs):


### PR DESCRIPTION
## Summary

`public/llms.txt` (added in #1348) is meant to be the machine-readable index an LLM uses to pick the right support page. As shipped it failed at both jobs.

**58 pages were silently missing.** `mkdocs-llmstxt` matches `sections` patterns with `fnmatch.filter()`, not pathlib globs. Under fnmatch `*` already crosses `/`, so `Section/**/*.md` expands to "literal `Section/`, anything, a literal `/`, anything, `.md`" — it requires at least one extra directory level and drops every page sitting directly in the section directory.

| Section | before | after | gained |
|---|---|---|---|
| Getting Started | 104 | 112 | 8 |
| Software | 71 | 74 | 3 |
| Batch Computing | **0** | 12 | 12 |
| Interactive Computing | 12 | 16 | 4 |
| Storage | 16 | 23 | 7 |
| Data Transfer | 12 | 24 | 12 |
| Policy | **0** | 10 | 10 |
| Service Subscriptions | 6 | 8 | 2 |
| **Total** | **238** | **296** | **+58** |

Batch Computing and Policy have no subdirectories at all, so both rendered empty — the worst possible gap in an HPC support index, since Slurm and allocation-policy questions are the bulk of real traffic. Other sections lost their landing/overview pages, the highest-value entries. The test plan on #1348 claimed "all 11 sections with working links"; that was wrong.

**Every link was bare** — title and URL, no description. Choosing between `Job_Arrays.md` and `Fair_Share.md` from titles alone means fetching both. The plugin never reads page front matter; descriptions come only from its own `sections` config, and a glob entry hands every page it matches the *same* description. So per-page descriptions need explicit per-page entries.

## Changes

Two commits:

1. **`mkdocs.yml`** — section patterns `Section/**/*.md` → `Section/*.md`, plus a comment explaining the fnmatch semantics so nobody "fixes" it back. Stands alone.
2. **`mkdocs_hooks.py`** — new `on_config` expands the section globs itself, reads each page's front matter `description`, and rewrites `sections` into explicit `{src_uri: description}` entries. `mkdocs.yml` keeps the globs as the readable declaration of section membership. Timing is safe: the plugin expands `sections` in `on_files`, hooks are appended last in the plugin collection, and `sections` is a `DictOfItems` validated at load time only. Pages without a usable description stay plain strings.

   **`checks/run_meta_check.py`** — new `meta_thin_description`, alongside the existing missing-description check. Flags descriptions too short to tell pages apart or that merely restate the title. Notice level, so it guides new and edited pages without failing CI on legacy ones.

## Results

```
total links: 298   (was 238)
with description: 131
Batch Computing: 12   (was 0)
Policy:          10   (was 0)
```

`meta_thin_description` flags 22 pages today, including eleven Freezer release-note pages all sharing `"Freezer upgrade release notes"`. The 30-character floor was picked by reading the actual list rather than guessed — descriptions in the low 30s ("Explanation of the 'oom-kill' error", "Overview of the REANNZ HPC filesystems") are still doing real work, so 40 was too aggressive.

## Follow-up (not in this PR)

167 pages have no `description` at all, so a consumer of `llms.txt` gets descriptions on 131/298 links. Bulk-generating those unreviewed would be worse than leaving them blank. Backlog is visible with:

```bash
shopt -s globstar && python3 checks/run_meta_check.py docs/**/*.md
```

Also worth an upstream issue on `mkdocs-llmstxt`: `**` silently meaning "requires an extra directory level" is a footgun, and the docs read like pathlib globs.

## Test plan

- [x] `mkdocs build --clean` — the four counts above all hit exactly
- [x] `./checks/run_test_build.py` from a clean state: exit 0, zero llmstxt warnings
- [x] `checks/run_meta_check.py` over all 307 pages: no traceback, 22 thin / 167 missing
- [x] Spot-checked entries against source front matter (with description, without, and nested more than one directory deep)
- [ ] CI (`checks.yml`) green
- [ ] PR preview (`demo_deploy.yml`): fetch `<preview-url>/llms.txt`, confirm Batch Computing and Policy are populated, follow two links

Note: running `run_test_build.py` twice in a row emits "Page URI not found in the generated pages" warnings. That is `dirty=True` skipping `on_page_content`, pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
