### PR TITLE
Fix changed-file detection, which was linting nothing

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -48,9 +48,20 @@ jobs:
       - name: Push Changed files to output
         if: inputs.fileList == ''
         id: diff
+        env:
+          # `github.base_ref` is only populated on pull_request events. This
+          # workflow triggers on push, where it is empty - the revision became
+          # the literal `origin/...HEAD`, the diff failed, and the file list came
+          # back empty, so every check below skipped with a green "no files to
+          # check". Fall back to the default branch.
+          BASE: ${{ github.base_ref || github.event.repository.default_branch }}
         run: |
-          changed_files="$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '^docs/.*\.md$' | tr '\n' ' ')"
-          echo "::info::Workflow triggered by PR"
+          if ! git rev-parse --verify --quiet "origin/${BASE}" > /dev/null; then
+            echo "::error title=Cannot determine changed files::origin/${BASE} does not exist"
+            exit 1
+          fi
+          echo "Comparing against origin/${BASE}"
+          changed_files="$(git diff --name-only "origin/${BASE}...HEAD" | grep -E '^docs/.*\.md$' | tr '\n' ' ' || true)"
           echo "Changed files: '${changed_files}'"
           echo "filelist=${changed_files}" >> $GITHUB_OUTPUT
     outputs:


### PR DESCRIPTION
## Summary

Every per-file check in `checks.yml` has been passing without looking at a single file. From the `Determine what files to check` job on #1355:

```
fatal: ambiguous argument 'origin/...HEAD': unknown revision or path not in the working tree.
::info::Workflow triggered by PR
Changed files: ''
```

and then, in `Check page meta`:

```
No files to check meta on.
```

**Cause.** `github.base_ref` is only populated on `pull_request` events. This workflow triggers on `push` (`branches-ignore: [main]`) and has no `pull_request` trigger at all, so `base_ref` is always empty. The revision in

```bash
git diff --name-only origin/${{ github.base_ref }}...HEAD
```

becomes the literal `origin/...HEAD`, the diff fails, and `changed_files` comes back empty. Each dependent job then hits its `if: ${{! needs.get.outputs.filelist}}` branch and exits 0.

So **Check Spelling, Check Prose, Check Markdown, Check page meta and Check slurm scripts have been green without running.** Only `Test build` was doing real work. The `::info::Workflow triggered by PR` line printed unconditionally, so the log asserted a trigger that hadn't happened.

## Fix

Fall back to the repository default branch when `base_ref` is empty, and **fail the step outright** if the base ref can't be resolved. Silently linting nothing is worse than a red job, because it reads as a pass — that's what let this sit unnoticed.

The base is passed through `env:` rather than interpolated into the script.

## Verification

Run locally against #1355, which changes 167 pages:

```
$ git diff --name-only "origin/main...origin/docs/add-missing-page-descriptions" | grep -E '^docs/.*\.md$' | wc -l
167
```

The old command yields an empty list on the same branch. The no-docs-changed case still works — `grep` finding no matches no longer aborts the step under `bash -e`.

Note this PR changes no `docs/*.md`, so its own run will legitimately report an empty list. The fix is exercised for real by the next PR that touches documentation.

## Scope

Only the `push` and `repository_dispatch` paths were affected. The `workflow_dispatch` path supplies `fileList` explicitly and is unchanged.

Heads up that once this lands, PRs may start surfacing lint findings on pages that have never actually been checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
