### PR TITLE
Fix preview URL mapping for index.md pages

### DIFF
--- a/.github/workflows/demo_deploy.yml
+++ b/.github/workflows/demo_deploy.yml
@@ -96,21 +96,35 @@ jobs:
         run: |
           changed_pages=$(gh api repos/${GITHUB_REPOSITORY}/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} \
             --jq '.files[] | select(.filename | endswith(".md")) | .filename')
-          urls="${DEPLOY_URL}/${GITHUB_REPOSITORY}/${HEAD}/"$'\n'
+          prefix="${DEPLOY_URL}/${GITHUB_REPOSITORY}/${HEAD}"
+          urls="${prefix}/"$'\n'
           for f in ${changed_pages}; do
-            g=${f#*/}; h=${g%.*}
-            urls="${urls}${DEPLOY_URL}/${GITHUB_REPOSITORY}/${HEAD}/${h}/"$'\n'
+            g=${f#*/}; h=${g%.md}
+            # use_directory_urls publishes `a/b.md` at `a/b/` and `a/b/index.md`
+            # at `a/b/`. Keeping the `index` segment points at a page that does
+            # not exist, and a 404 breaks the audit below - see that step.
+            # Matched as a whole path segment so `reindex.md` survives intact.
+            case "$h" in
+              index) h="" ;;
+              */index) h="${h%/index}" ;;
+            esac
+            urls="${urls}${prefix}${h:+/$h}/"$'\n'
           done
+          # docs/index.md maps onto the site root, which is already the first entry.
+          urls=$(printf '%s' "${urls}" | awk 'NF && !seen[$0]++')
           echo "urls<<EOF" >> $GITHUB_OUTPUT
           echo "$urls" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Wait for preview URLs to be live
         if: steps.wait.outputs.conclusion == 'success'
+        env:
+          URLS: ${{ steps.pages.outputs.urls }}
         run: |
           # GitHub Pages CDN can lag behind the deploy; a URL that 404s serves
           # GitHub's default 404 page, whose strict CSP breaks AccessLint's
           # script injection. Poll each URL until it returns 200 first.
+          failed=""
           while IFS= read -r url; do
             [ -z "$url" ] && continue
             echo "Waiting for $url"
@@ -123,7 +137,14 @@ jobs:
               echo "  Got $code, retrying (${i}/30)..."
               sleep 5
             done
-          done <<< "${{ steps.pages.outputs.urls }}"
+            # Falling through with a non-200 used to be silent, and the audit
+            # then died on that URL with an unrelated-looking CSP error.
+            if [ "$code" != "200" ]; then
+              echo "::error title=Preview URL never became live::${url} last returned ${code}"
+              failed="${failed} ${url}"
+            fi
+          done <<< "${URLS}"
+          [ -z "${failed}" ]
 
       - name: Run AccessLint WCAG audit
         if: steps.wait.outputs.conclusion == 'success'

--- a/.github/workflows/demo_deploy.yml
+++ b/.github/workflows/demo_deploy.yml
@@ -76,8 +76,17 @@ jobs:
               if [ -n "${changed_pages}" ]; then
                   msg="${msg}<br><br>Seems the following pages differ;<br><ul>"
                   for f in ${changed_pages};do
-                      g=${f#*/}; h=${g%.*}
-                      msg="${msg}<li><a href=\"${DEPLOY_URL}/${GITHUB_REPOSITORY}/${HEAD}/${h}\" target=_blank>${h##*/}</a></li>"
+                      g=${f#*/}; h=${g%.md}
+                      # `a/b/index.md` is published at `a/b/` - see the URL
+                      # mapping step below. Without this the link 404s and is
+                      # labelled "index".
+                      case "$h" in
+                        index) h="" ;;
+                        */index) h="${h%/index}" ;;
+                      esac
+                      label="${h##*/}"
+                      if [ -z "${label}" ]; then label="Home"; fi
+                      msg="${msg}<li><a href=\"${DEPLOY_URL}/${GITHUB_REPOSITORY}/${HEAD}/${h}\" target=_blank>${label}</a></li>"
                   done
                   msg="${msg}</ul>"
                   echo "::info title=Deploy Succeeded::${DEPLOY_URL}/${GITHUB_REPOSITORY}/${HEAD}" 


### PR DESCRIPTION
## Summary

The deploy job on #1355 failed three URLs into the accessibility audit:

```
##[error]page.addScriptTag: Executing inline script violates the following Content Security Policy
directive 'default-src 'none''. ... The action has been blocked.
##[error]Process completed with exit code 1.
```

AccessLint injects axe as an inline script, so it cannot audit a page whose response carries a strict CSP — which is exactly what GitHub Pages serves on a 404. The URL it choked on was `.../Announcements/Release_Notes/index/`, and that page does not exist: with `use_directory_urls`, mkdocs publishes `a/b/index.md` at `a/b/`, not `a/b/index/`.

`demo_deploy.yml:101` stripped only the extension:

```bash
g=${f#*/}; h=${g%.*}
```

leaving the `index` segment behind and pointing the audit at a 404. The audit then produced no report, and the `Post accessibility report on PR` step failed with `Either message or path input is required`.

This never fired before because no recent PR had touched an `index.md`. #1355 touches three.

## Changes

**Strip a trailing `index` path segment**, and map `docs/index.md` onto the site root. Matched with a `case` pattern rather than `${h%index}` so a page like `reindex.md` isn't truncated to `re`. The site root is already the first URL in the list, so the list is deduplicated.

**The same bug in the PR comment.** The "pages differ" list built its links the same way, so a changed `a/b/index.md` was linked to a 404 and labelled "index". Same handling, with the root page labelled "Home".

**Fail when a preview URL never goes live.** The wait loop already existed to keep 404s away from the audit — its comment says exactly that — but it gave up silently after 30 tries and let the audit run anyway. It now reports the URL and its status code, so the next occurrence reads as "preview URL never became live" instead of an unrelated-looking CSP error. It's also where most of that run's 10m34s went, spinning 150s each on three URLs that were never going to resolve.

**Pass the URL list through `env:`** instead of interpolating it into the script. It derives from the head branch name, which a fork PR controls and which may contain a double quote.

## Verification

The mapping logic, run against a representative file list:

| input | URL |
|---|---|
| `docs/index.md` | `BASE/` (deduplicated against the root entry) |
| `docs/Announcements/Release_Notes/index.md` | `BASE/Announcements/Release_Notes/` |
| `docs/Software/Available_Applications/index.md` | `BASE/Software/Available_Applications/` |
| `docs/Batch_Computing/Fair_Share.md` | `BASE/Batch_Computing/Fair_Share/` |
| `docs/Software/reindex.md` | `BASE/Software/reindex/` — not mangled |

This PR changes no `docs/*.md`, so its own run audits only the site root and won't exercise the index path. The real check is re-running the deploy on #1355 once this lands — it has all three `index.md` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
